### PR TITLE
Fix print output for radix2 FFT

### DIFF
--- a/maths/radix2_fft.py
+++ b/maths/radix2_fft.py
@@ -158,13 +158,13 @@ class FFT:
     # Overwrite __str__ for print(); Shows A, B and A*B
     def __str__(self):
         a = "A = " + " + ".join(
-            f"{coef}*x^{i}" for coef, i in enumerate(self.polyA[: self.len_A])
+            f"{coef}*x^{i}" for i, coef in enumerate(self.polyA[: self.len_A])
         )
         b = "B = " + " + ".join(
-            f"{coef}*x^{i}" for coef, i in enumerate(self.polyB[: self.len_B])
+            f"{coef}*x^{i}" for i, coef in enumerate(self.polyB[: self.len_B])
         )
         c = "A*B = " + " + ".join(
-            f"{coef}*x^{i}" for coef, i in enumerate(self.product)
+            f"{coef}*x^{i}" for i, coef in enumerate(self.product)
         )
 
         return f"{a}\n{b}\n{c}"


### PR DESCRIPTION
## Summary
- correct coefficient/index order in `FFT.__str__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683f3a7a15c883289e397b56095f1542