### PR TITLE
Fix typos in knapsack docs

### DIFF
--- a/knapsack/greedy_knapsack.py
+++ b/knapsack/greedy_knapsack.py
@@ -12,7 +12,7 @@ Constraints:
 max_weight > 0
 profit[i] >= 0
 weight[i] >= 0
-Calculate the maximum profit that the shopkeeper can make given maxmum weight that can
+Calculate the maximum profit that the shopkeeper can make given maximum weight that can
 be carried.
 """
 

--- a/knapsack/recursive_approach_knapsack.py
+++ b/knapsack/recursive_approach_knapsack.py
@@ -12,7 +12,7 @@ Constraints:
 max_weight > 0
 profit[i] >= 0
 weight[i] >= 0
-Calculate the maximum profit that the shopkeeper can make given maxmum weight that can
+Calculate the maximum profit that the shopkeeper can make given maximum weight that can
 be carried.
 """
 


### PR DESCRIPTION
## Summary
- fix typos in the greedy and recursive knapsack module docstrings

## Testing
- `ruff check knapsack/greedy_knapsack.py knapsack/recursive_approach_knapsack.py`
- `pytest knapsack/tests/test_greedy_knapsack.py knapsack/tests/test_knapsack.py`


------
https://chatgpt.com/codex/tasks/task_e_683f5384c27c832897fc10251e5a12e4