### PR TITLE
Fix parameter order in decision tree mse

### DIFF
--- a/machine_learning/decision_tree.py
+++ b/machine_learning/decision_tree.py
@@ -96,7 +96,7 @@ class DecisionTree:
             return
 
         best_split = 0
-        min_error = self.mean_squared_error(x, np.mean(y)) * 2
+        min_error = self.mean_squared_error(y, np.mean(y)) * 2
 
         """
         loop over all possible splits for the decision tree. find the best split.


### PR DESCRIPTION
## Summary
- fix mean squared error call in DecisionTree

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683f546bda7483288baad828653cbc5f