### PR TITLE
Fix duplicate word in Burkes docstring

### DIFF
--- a/digital_image_processing/dithering/burkes.py
+++ b/digital_image_processing/dithering/burkes.py
@@ -9,7 +9,7 @@ from cv2 import destroyAllWindows, imread, imshow, waitKey
 class Burkes:
     """
     Burke's algorithm is using for converting grayscale image to black and white version
-    Source: Source: https://en.wikipedia.org/wiki/Dither
+    Source: https://en.wikipedia.org/wiki/Dither
 
     Note:
         * Best results are given with threshold= ~1/2 * max greyscale value.


### PR DESCRIPTION
## Summary
- fix duplicate `Source:` in digital_image_processing/dithering/burkes.py

## Testing
- `ruff check digital_image_processing/dithering/burkes.py`
- `mypy --ignore-missing-imports digital_image_processing/dithering/burkes.py`
- `python3 -m doctest -v digital_image_processing/dithering/burkes.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683f547da4688328a174c63e6ac40d83